### PR TITLE
explicitly set InputControl value on editing

### DIFF
--- a/rxpm/src/main/kotlin/me/dmdev/rxpm/widget/InputControl.kt
+++ b/rxpm/src/main/kotlin/me/dmdev/rxpm/widget/InputControl.kt
@@ -96,6 +96,10 @@ infix fun InputControl.bindTo(editText: EditText) {
                 val ss = SpannableString(it)
                 TextUtils.copySpansFrom(editable, 0, ss.length, null, ss, 0)
                 editable.replace(0, editable.length, ss)
+
+                val selection = editText.selectionStart
+                editText.text = editable
+                editText.setSelection(selection)
             } else {
                 editable.replace(0, editable.length, it)
             }


### PR DESCRIPTION
This pull request fixes the bug with the InputControl formatting when EditText's Editable is an instance of Spanned.